### PR TITLE
output failure message when response code is not 200

### DIFF
--- a/ddgo.go
+++ b/ddgo.go
@@ -199,6 +199,10 @@ func createMonitors() {
 			log.Println("response body:", string(b))
 			return
 		}
+		if resp.StatusCode != 200 {
+			fmt.Println("failed with response status code:", resp.StatusCode)
+			return
+		}
 		// log.Println(LogSeparator, "createAMonitor", LogSeparator)
 		fmt.Println("created:", monitorName)
 		// log.Println(string(b))


### PR DESCRIPTION
When API_KEY or APPLICATION_KEY is wrong, Datadog returns 403, but the log says "created" since it does not check the status code of the HTTP response.
This pull request adds a simple check for the HTTP response to verify that the status code is 200.